### PR TITLE
Support LibreTiny platform

### DIFF
--- a/library.json
+++ b/library.json
@@ -45,7 +45,8 @@
    "license": "BSD-3-Clause",
    "platforms": [
       "espressif32",
-      "espressif8266"
+      "espressif8266",
+      "libretiny"
    ],
    "frameworks":[
       "espidf",

--- a/src/esp_wireguard.c
+++ b/src/esp_wireguard.c
@@ -208,7 +208,11 @@ esp_err_t esp_wireguard_init(wireguard_config_t *config, wireguard_ctx_t *ctx)
 
     err = wireguard_platform_init();
     if (err != ESP_OK) {
+#if !defined(LIBRETINY)
         ESP_LOGE(TAG, "wireguard_platform_init: %s", esp_err_to_name(err));
+#else // !defined(LIBRETINY)
+        ESP_LOGE(TAG, "wireguard_platform_init: %d", err);
+#endif // !defined(LIBRETINY)
         goto fail;
     }
     ctx->config = config;
@@ -233,7 +237,11 @@ esp_err_t esp_wireguard_connect(wireguard_ctx_t *ctx)
     if (ctx->netif == NULL) {
         err = esp_wireguard_netif_create(ctx->config);
         if (err != ESP_OK) {
+#if !defined(LIBRETINY)
             ESP_LOGE(TAG, "netif_create: %s", esp_err_to_name(err));
+#else // !defined(LIBRETINY)
+            ESP_LOGE(TAG, "netif_create: %d", err);
+#endif // !defined(LIBRETINY)
             goto fail;
         }
         ctx->netif = wg_netif;
@@ -271,7 +279,11 @@ esp_err_t esp_wireguard_connect(wireguard_ctx_t *ctx)
         /* Initialize the first WireGuard peer structure */
         err = esp_wireguard_peer_init(ctx->config, &peer);
         if (err != ESP_OK) {
+#if !defined(LIBRETINY)
             ESP_LOGE(TAG, "peer_init: %s", esp_err_to_name(err));
+#else // !defined(LIBRETINY)
+            ESP_LOGE(TAG, "peer_init: %d", err);
+#endif // !defined(LIBRETINY)
             goto fail;
         }
 

--- a/src/esp_wireguard_err.h
+++ b/src/esp_wireguard_err.h
@@ -31,7 +31,11 @@
 #if !defined(__ESP_WIREGUARD_ERR__H__)
 #define __ESP_WIREGUARD_ERR__H__
 
-#if defined(ESP8266) && !defined(IDF_VER)
+#if defined(LIBRETINY)
+#undef esp_err_t
+#endif
+
+#if defined(ESP8266) && !defined(IDF_VER) || defined(LIBRETINY)
 typedef int esp_err_t;
 
 #define ESP_OK          0       /*!< esp_err_t value indicating success (no error) */

--- a/src/esp_wireguard_log.h
+++ b/src/esp_wireguard_log.h
@@ -56,8 +56,10 @@
 #define ESP_LOGV(tag, ...) _noop(tag, __VA_ARGS__)
 #endif
 
-#else  // defined(ESP8266) && !defined(IDF_VER)
+#elif defined(LIBRETINY)
+#include <libretiny.h>
+#else // defined(LIBRETINY)
 #include <esp_log.h>
-#endif  // defined(ESP8266) && !defined(IDF_VER)
+#endif // defined(ESP8266) && !defined(IDF_VER)
 
 #endif  // __ESP_WIREGUARD_LOG__H__

--- a/src/wireguardif.c
+++ b/src/wireguardif.c
@@ -49,10 +49,10 @@
 #include "esp_wireguard_log.h"
 #include "esp_wireguard_err.h"
 
-#if !defined(ESP8266) || defined(IDF_VER)
+#if (!defined(ESP8266) || defined(IDF_VER)) && !defined(LIBRETINY)
 #include <sys/socket.h>
 #include "esp_netif.h"
-#endif  // !defined(ESP8266) || defined(IDF_VER)
+#endif  // (!defined(ESP8266) || defined(IDF_VER)) && !defined(LIBRETINY)
 
 #include "wireguard.h"
 #include "crypto.h"
@@ -948,7 +948,7 @@ err_t wireguardif_init(struct netif *netif) {
 
 	struct netif* underlying_netif = NULL;
 
-#if !defined(ESP8266) || defined(IDF_VER)
+#if (!defined(ESP8266) || defined(IDF_VER)) && !defined(LIBRETINY)
 	char lwip_netif_name[8] = {0,};
 
 	// list of interfaces to try to bind wireguard to
@@ -970,15 +970,21 @@ err_t wireguardif_init(struct netif *netif) {
 	}
 
 	underlying_netif = netif_find(lwip_netif_name);
-#else  // !defined(ESP8266) || defined(IDF_VER)
-	underlying_netif = netif_default;
-#endif  // !defined(ESP8266) || defined(IDF_VER)
 
 	if (underlying_netif == NULL) {
 		ESP_LOGE(TAG, "netif_find: cannot find %s (%s)", ifkey, lwip_netif_name);
 		result = ERR_IF;
 		goto fail;
 	}
+#else  // (!defined(ESP8266) || defined(IDF_VER)) && !defined(LIBRETINY)
+	underlying_netif = netif_default;
+
+	if (underlying_netif == NULL) {
+		ESP_LOGE(TAG, "netif_find: cannot find default netif");
+		result = ERR_IF;
+		goto fail;
+	}
+#endif  // (!defined(ESP8266) || defined(IDF_VER)) && !defined(LIBRETINY)
 
 	ESP_LOGV(TAG, "underlying_netif = %p", underlying_netif);
 


### PR DESCRIPTION
This PR adds support for the [LibreTiny](https://docs.libretiny.eu/) platform, supported in ESPHome for a few months now.

This has been tested on BK7231T chip (should also work on BK7231N), it works flawlessly after a tiny change in LibreTiny.

The Realtek RTL8710B platform wasn't tested.

No ESPHome changes are required for this to work (well, a LibreTiny version bump is).