### PR TITLE
Add publish and Release Drafter workflows

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,36 @@
+# Tags carry a "v" prefix (v0.4.5, v0.4.4, ...), while library.json holds the
+# bare version. publish.yml packs from library.json, so keep the two in sync.
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "Breaking Changes"
+    label: "breaking-change"
+  - title: "Dependencies"
+    collapse-after: 1
+    labels:
+      - "dependencies"
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+      - "breaking-change"
+  minor:
+    labels:
+      - "minor"
+      - "new-feature"
+  patch:
+    labels:
+      - "bugfix"
+      - "dependencies"
+      - "documentation"
+      - "enhancement"
+  default: patch
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  publish-platformio:
+    name: Publish to PlatformIO
+    runs-on: ubuntu-latest
+    environment: platformio
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.x'
+      - name: Install platformio
+        run: pip install --upgrade platformio
+      - name: Publish package
+        env:
+          PLATFORMIO_AUTH_TOKEN: ${{ secrets.PLATFORMIO_AUTH_TOKEN }}
+        run: pio package publish --owner esphome --non-interactive

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,50 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - dev
+
+permissions: {}
+
+jobs:
+  release-drafter:
+    name: Release Drafter
+    environment: release-drafter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
+        id: drafter
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      # library.json has several "version" keys - the library's own, plus one
+      # per entry in "dependencies". Only the first line matching is rewritten
+      # so the dependency constraints are left alone.
+      - name: Update version files
+        env:
+          RESOLVED_VERSION: ${{ steps.drafter.outputs.resolved_version }}
+        run: |
+          sed -i "0,/\"version\":/s/^\( *\)\"version\": .*/\1\"version\": \"${RESOLVED_VERSION}\",/" library.json
+
+      - name: Commit changes
+        env:
+          RESOLVED_VERSION: ${{ steps.drafter.outputs.resolved_version }}
+        run: |
+          if ! git diff --quiet; then
+            git config --global user.name "esphome-libs[bot]"
+            git config --global user.email "272321744+esphome-libs[bot]@users.noreply.github.com"
+            git commit -am "Bump version to ${RESOLVED_VERSION}"
+            git push
+          fi


### PR DESCRIPTION
## Summary

Adds the release automation the other esphome-libs repos use, adapted to this library.

`.github/workflows/release-drafter.yml` runs on every push to `dev` (this repo's default branch). It keeps a draft release up to date, resolves the next version from PR labels, writes it into `library.json`, and commits the bump as `esphome-libs[bot]`.

`.github/workflows/publish.yml` runs when a release is published and pushes the packed library to PlatformIO under the `esphome` owner.

`.github/release-drafter.yml` holds the categories and version resolver. Tags stay `v`-prefixed to match the existing `v0.4.5`, `v0.4.4`, ... history, while `library.json` keeps the bare version.

## Notes

There is no `publish-espressif` job. That job needs an `idf_component.yml`, which this repo does not have, and there is no `esphome/esp_wireguard` component registered at components.espressif.com. Adding IDF component publishing means authoring that manifest first, so it is left for a separate change.

The `library.json` bump rewrites only the first `"version":` line. The `dependencies` entries have `"version"` keys too and must not be touched.

Action pins are the current latest, resolved to peeled commit SHAs: checkout v7.0.1, setup-python v7.0.0, create-github-app-token v3.2.0, release-drafter v7.7.0.

Before this can run green, the repo needs the `release-drafter` and `platformio` environments, plus `vars.ESPHOME_GITHUB_APP_CLIENT_ID`, `secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY` and `secrets.PLATFORMIO_AUTH_TOKEN`. Also worth flagging: the PlatformIO package currently lives under `droscy/esp_wireguard` (that is what ESPHome's `wireguard` component pulls), so the first `--owner esphome` publish creates a new package rather than updating the existing one.