### PR TITLE
Rename library to wireguard and update repository URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,23 @@ for [ESPHome](https://esphome.io/), based on
 [Wireguard Implementation for ESP-IDF](https://github.com/trombik/esp_wireguard)
 (by [@trombik](https://github.com/trombik)).
 
-[![PlatformIO Registry](https://badges.registry.platformio.org/packages/droscy/library/esp_wireguard.svg)](https://registry.platformio.org/libraries/droscy/esp_wireguard)
+[![PlatformIO Registry](https://badges.registry.platformio.org/packages/esphome/library/wireguard.svg)](https://registry.platformio.org/libraries/esphome/wireguard)
 
 
 ## Usage
 
 Please refer to the official documentation of [WireGuard Component](https://esphome.io/components/wireguard)
 in ESPHome website.
+
+The library is published to the PlatformIO Registry as `esphome/wireguard`:
+
+```ini
+lib_deps = esphome/wireguard
+```
+
+> **Note:** this library was previously named `esp_wireguard` and published as
+> `droscy/esp_wireguard`. Only the package and repository names changed; the C API
+> (`esp_wireguard.h`, `esp_wireguard_init()`, ...) is unchanged.
 
 
 ## Compatibility
@@ -31,6 +41,8 @@ For additional information see:
 * the first pull-request [esphome/esphome#4256](https://github.com/esphome/esphome/pull/4256)
 * `esp8266` support [esphome/esphome#6365](https://github.com/esphome/esphome/pull/6365)
 * LibreTiny support [droscy/esp_wireguard#4](https://github.com/droscy/esp_wireguard/pull/4)
+  (in the repository this library was forked from, before the move to
+  [esphome-libs/wireguard](https://github.com/esphome-libs/wireguard))
 
 
 ## License

--- a/library.json
+++ b/library.json
@@ -1,5 +1,5 @@
 {
-   "name": "esp_wireguard",
+   "name": "wireguard",
    "version": "0.4.5",
    "description": "WireGuard implementation for ESPHome",
    "keywords":[
@@ -11,9 +11,10 @@
    ],
    "repository":{
       "type": "git",
-      "url": "https://github.com/droscy/esp_wireguard",
+      "url": "https://github.com/esphome-libs/wireguard.git",
       "branch": "main"
    },
+   "homepage": "https://github.com/esphome-libs/wireguard",
    "authors":[
       {
          "name": "Simone Rossetto",


### PR DESCRIPTION
## Summary

Renames the library from `esp_wireguard` to `wireguard` now that it lives in the `esphome-libs` organisation, and points the metadata and docs at the new home.

- `library.json`: `name` is now `wireguard`, `repository.url` points at `https://github.com/esphome-libs/wireguard.git`, and a `homepage` field was added to match the other `esphome-libs` repos (`esp-hub75`, `esp-audio-libs`).
- `README.md`: the PlatformIO badge and link now target `esphome/wireguard`. `esphome-libs` repos publish under the `esphome` registry owner, as confirmed by `esp-hub75` and by the `esphome/libsodium` dependency already declared in this repo's `library.json`. A `lib_deps` snippet and a short note about the old name were added, and the historical `droscy/esp_wireguard#4` reference was annotated rather than rewritten since that URL still resolves.

## What is deliberately unchanged

The C API keeps its names: `include/esp_wireguard.h`, `src/esp_wireguard.c`, `esp_wireguard_err.h`, `esp_wireguard_log.h` and the `esp_wireguard_*()` functions. Two reasons: `src/wireguard.h` and `src/wireguard.c` already exist (the core protocol implementation from the upstream lwIP port), so renaming the public header would collide; and ESPHome includes those headers and calls those functions directly, so renaming them turns a metadata change into a breaking API change.

## Follow-ups needed outside this repo

- Rename the GitHub repository itself from `esphome-libs/esp_wireguard` to `esphome-libs/wireguard`.
- Publish the package to the PlatformIO registry under the new name, then update `cg.add_library("droscy/esp_wireguard", "0.4.5")` in `esphome/components/wireguard/__init__.py`.

The esphome-docs `wireguard` component page never references the library repo or package name, so no docs change is needed there.