### PR TITLE
Add ESP Component Registry publishing and CMake build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,13 @@ jobs:
         id: version
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-        run: echo "version=${TAG_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          version="${TAG_NAME#v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)*$ ]]; then
+            echo "::error::Release tag '${TAG_NAME}' is not a version the component registry will accept."
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
       - name: Publish package
         uses: espressif/upload-components-ci-action@2ce17d73e35473317c1419dbd4f007aacb593040 # v2.2.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,3 +25,28 @@ jobs:
         env:
           PLATFORMIO_AUTH_TOKEN: ${{ secrets.PLATFORMIO_AUTH_TOKEN }}
         run: pio package publish --owner esphome --non-interactive
+
+  publish-espressif:
+    name: Publish to Espressif
+    runs-on: ubuntu-latest
+    environment: espressif
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # The registry requires a bare semver version, and this repo's release
+      # tags carry a v prefix. The action only strips it in its `git` mode,
+      # so strip it here and pass the version explicitly.
+      - name: Resolve version
+        id: version
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: echo "version=${TAG_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Publish package
+        uses: espressif/upload-components-ci-action@2ce17d73e35473317c1419dbd4f007aacb593040 # v2.2.1
+        with:
+          version: ${{ steps.version.outputs.version }}
+          components: |
+            wireguard: .
+          namespace: esphome

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           version="${TAG_NAME#v}"
-          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)*$ ]]; then
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Release tag '${TAG_NAME}' is not a version the component registry will accept."
             exit 1
           fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,57 @@
+set(WIREGUARD_SRCS
+  "src/crypto.c"
+  "src/crypto/refc/blake2s.c"
+  "src/crypto/refc/chacha20.c"
+  "src/crypto/refc/chacha20poly1305.c"
+  "src/crypto/refc/poly1305-donna.c"
+  "src/esp_wireguard.c"
+  "src/wireguard.c"
+  "src/wireguardif.c"
+  "src/wireguard-platform.c"
+)
+
+# mbedtls_ctr_drbg_random()'s return value is deliberately ignored in a few
+# places; the sources are upstream's and are not warning-clean without this.
+set(WIREGUARD_COMPILE_OPTIONS
+  "-Wno-unused-result"
+)
+
+if(ESP_PLATFORM)
+  # ESP-IDF component build.
+  #
+  # src is a public include dir, not a private one: the public
+  # include/esp_wireguard.h includes esp_wireguard_err.h, which lives in src.
+  idf_component_register(
+    SRCS ${WIREGUARD_SRCS}
+    INCLUDE_DIRS "include" "src"
+    REQUIRES lwip
+    PRIV_REQUIRES esp_netif mbedtls esphome__libsodium
+  )
+
+  target_compile_options(${COMPONENT_LIB} PRIVATE ${WIREGUARD_COMPILE_OPTIONS})
+else()
+  # Generic CMake build, for consumers that pull this repo in with
+  # add_subdirectory().
+  cmake_minimum_required(VERSION 3.13)
+
+  add_library(wireguard STATIC ${WIREGUARD_SRCS})
+  add_library(esphome::wireguard ALIAS wireguard)
+
+  target_include_directories(wireguard PUBLIC
+    "${CMAKE_CURRENT_LIST_DIR}/include"
+    # Public, not private: include/esp_wireguard.h includes
+    # esp_wireguard_err.h, which lives in src.
+    "${CMAKE_CURRENT_LIST_DIR}/src"
+  )
+
+  target_compile_options(wireguard PRIVATE ${WIREGUARD_COMPILE_OPTIONS})
+
+  # crypto.h pulls in <sodium.h> for crypto_scalarmult_curve25519(), so link a
+  # libsodium target if the consumer has already defined one. lwip and mbedtls
+  # are likewise the consumer's to provide; outside ESP-IDF there is no single
+  # canonical target name for either, so they are left to the consumer's
+  # include path and link line.
+  if(TARGET sodium)
+    target_link_libraries(wireguard PUBLIC sodium)
+  endif()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,11 +46,18 @@ else()
 
   target_compile_options(wireguard PRIVATE ${WIREGUARD_COMPILE_OPTIONS})
 
+  # This branch is not a portable host build: unless the consumer is building
+  # for ESP8266 (non-IDF) or LibreTiny, which esp_wireguard_err.h and
+  # esp_wireguard_log.h have fallbacks for, the sources still expect the
+  # ESP-IDF headers esp_err.h, esp_log.h, esp_system.h and esp_netif.h. It
+  # exists for toolchains such as LibreTiny that drive CMake themselves; an
+  # ESP-IDF project should use the component build above instead.
+  #
   # crypto.h pulls in <sodium.h> for crypto_scalarmult_curve25519(), so link a
-  # libsodium target if the consumer has already defined one. lwip and mbedtls
-  # are likewise the consumer's to provide; outside ESP-IDF there is no single
-  # canonical target name for either, so they are left to the consumer's
-  # include path and link line.
+  # libsodium target if the consumer has already defined one. lwip, mbedtls and
+  # the platform headers are the consumer's to provide; outside ESP-IDF there
+  # is no canonical target name for any of them, so they are left to the
+  # consumer's include path and link line.
   if(TARGET sodium)
     target_link_libraries(wireguard PUBLIC sodium)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,13 @@ if(ESP_PLATFORM)
 else()
   # Generic CMake build, for consumers that pull this repo in with
   # add_subdirectory().
-  cmake_minimum_required(VERSION 3.13)
+  #
+  # Guarded: from a subdirectory this would reset policy settings for this
+  # scope to the 3.13 baseline, overriding whatever the consuming project
+  # selected with its own, newer cmake_minimum_required().
+  if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    cmake_minimum_required(VERSION 3.13)
+  endif()
 
   add_library(wireguard STATIC ${WIREGUARD_SRCS})
   add_library(esphome::wireguard ALIAS wireguard)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ resolved by the component manager.
 ### Plain CMake
 
 Outside of ESP-IDF, `CMakeLists.txt` defines an ordinary static library target,
-so any CMake project can consume it directly:
+so a CMake project can consume it with `add_subdirectory()`:
 
 ```cmake
 add_subdirectory(path/to/wireguard)
@@ -48,9 +48,20 @@ target_link_libraries(my_target PRIVATE esphome::wireguard)
 ```
 
 The target is named `wireguard`, with `esphome::wireguard` as an alias. Include
-directories and the warning suppressions are carried on the target; lwip,
-mbedtls and libsodium are the consuming project's to provide. If a `sodium`
-target already exists it is linked automatically.
+directories and the warning suppressions are carried on the target.
+
+This is not a portable host build. The sources still expect an ESP-family SDK,
+so the consuming project has to put the following on the include path itself:
+
+* lwip, mbedtls and libsodium (if a `sodium` target already exists it is linked
+  automatically, otherwise link your own);
+* unless building for ESP8266 (non-IDF) or LibreTiny, which have their own
+  fallbacks in `esp_wireguard_err.h` and `esp_wireguard_log.h`, the ESP-IDF
+  headers `esp_err.h`, `esp_log.h`, `esp_system.h` and `esp_netif.h`.
+
+In other words, this branch of the build exists for toolchains such as
+LibreTiny and the ESP8266 SDK that drive CMake themselves; an ESP-IDF project
+should use the component build above rather than `add_subdirectory()`.
 
 
 ## Compatibility

--- a/README.md
+++ b/README.md
@@ -24,6 +24,35 @@ lib_deps = esphome/wireguard
 > (`esp_wireguard.h`, `esp_wireguard_init()`, ...) is unchanged.
 
 
+### ESP-IDF component
+
+The library is also published to the [ESP Component Registry](https://components.espressif.com/components/esphome/wireguard)
+as `esphome/wireguard`, so an ESP-IDF project can add it with:
+
+```console
+idf.py add-dependency "esphome/wireguard"
+```
+
+The `esphome/libsodium` dependency is declared in `idf_component.yml` and is
+resolved by the component manager.
+
+
+### Plain CMake
+
+Outside of ESP-IDF, `CMakeLists.txt` defines an ordinary static library target,
+so any CMake project can consume it directly:
+
+```cmake
+add_subdirectory(path/to/wireguard)
+target_link_libraries(my_target PRIVATE esphome::wireguard)
+```
+
+The target is named `wireguard`, with `esphome::wireguard` as an alias. Include
+directories and the warning suppressions are carried on the target; lwip,
+mbedtls and libsodium are the consuming project's to provide. If a `sodium`
+target already exists it is linked automatically.
+
+
 ## Compatibility
 
 This code targets only ESPHome and has been tested on the following platforms:

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,11 @@
+description: WireGuard implementation for ESPHome
+version: "0.4.6"
+url: https://github.com/esphome-libs/wireguard
+repository: https://github.com/esphome-libs/wireguard.git
+license: BSD-3-Clause
+dependencies:
+  esphome/libsodium: "^1.10021.1"
+files:
+  exclude:
+    - ".github/**/*"
+    - "TODO.md"


### PR DESCRIPTION
Brings this repo in line with the sibling `libsodium` and `noise-c` ports: the library can now be consumed as an ESP-IDF managed component or by a plain CMake project, not only through PlatformIO.

**`CMakeLists.txt`** is dual-mode. Under ESP-IDF it calls `idf_component_register` with `REQUIRES lwip` (the public `esp_wireguard.h` includes `lwip/netif.h`) and `PRIV_REQUIRES esp_netif mbedtls esphome__libsodium`. Otherwise it defines an ordinary static library target `wireguard` with an `esphome::wireguard` alias, linking a `sodium` target if the consumer already defined one. In both branches `src` is a public include dir rather than a private one, because `include/esp_wireguard.h` includes `esp_wireguard_err.h`, which lives in `src`. The `-Wno-unused-result` flag is carried over from `library.json`.

**`idf_component.yml`** declares the manifest and the `esphome/libsodium` dependency. The constraint is `^1.10021.1` rather than `library.json`'s `^1.10018.1` because only 1.10021.1 and 1.10021.2 were ever published to the registry.

**`publish.yml`** gains a `publish-espressif` job using `espressif/upload-components-ci-action`, mirroring the libsodium and noise-c workflows. One deviation: those repos tag releases bare (`1.10021.2`) while this one uses a `v` prefix. The action only strips the `v` in its `git` mode - an explicit `version:` input is passed through verbatim and would fail the registry's semver validation - so a small step strips it before the action runs.

Verified locally: `compote component pack` validates the manifest and produces the expected tarball, and a minimal ESP-IDF project building the component for `esp32` completes with `esphome/libsodium` resolved automatically from the registry, no warnings or errors from any wireguard source, and no missing headers or undefined references.