### PR TITLE
Add compile tests for the ESP-IDF and CMake build files

### DIFF
--- a/.github/scripts/check_component_archive.sh
+++ b/.github/scripts/check_component_archive.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Check the archive produced by `compote component pack` against the
+# files.exclude rules in idf_component.yml.
+#
+# Packing on its own only proves the manifest parses. This additionally proves
+# the exclude rules do something, and that the files a consumer actually needs
+# survived them.
+set -euo pipefail
+
+dist_dir="${1:-dist}"
+
+if ! archives=$(find "${dist_dir}" -maxdepth 1 -name '*.tgz' -type f); then
+    echo "::error::failed to list ${dist_dir}"
+    exit 1
+fi
+
+archive_list=()
+if [ -n "${archives}" ]; then
+    mapfile -t archive_list <<< "${archives}"
+fi
+
+if [ "${#archive_list[@]}" -ne 1 ]; then
+    echo "::error::expected exactly one archive in ${dist_dir}, found ${#archive_list[@]}"
+    exit 1
+fi
+
+archive="${archive_list[0]}"
+echo "Checking ${archive}"
+
+if ! contents=$(tar -tzf "${archive}"); then
+    echo "::error::failed to read ${archive}"
+    exit 1
+fi
+
+# tar entries may or may not carry a leading "./", so compare on a normalised
+# copy rather than on the raw listing.
+normalised=$(printf '%s\n' "${contents}" | sed 's|^\./||')
+
+status=0
+
+# Paths the manifest excludes. A published component carrying these would mean
+# a files.exclude rule stopped matching.
+excluded_prefixes=(
+    ".github/"
+    "tests/"
+)
+excluded_files=(
+    "TODO.md"
+)
+
+for prefix in "${excluded_prefixes[@]}"; do
+    matches=$(printf '%s\n' "${normalised}" | grep "^${prefix}" || true)
+    if [ -n "${matches}" ]; then
+        echo "::error::${prefix} should be excluded but the archive contains:"
+        printf '%s\n' "${matches}" | sed 's/^/  /'
+        status=1
+    fi
+done
+
+for file in "${excluded_files[@]}"; do
+    if printf '%s\n' "${normalised}" | grep -qx "${file}"; then
+        echo "::error::${file} should be excluded but is present in the archive"
+        status=1
+    fi
+done
+
+# The exclude rules must not have taken the component with them. These are the
+# files a consumer cannot build without.
+required_files=(
+    "CMakeLists.txt"
+    "idf_component.yml"
+    "include/esp_wireguard.h"
+    "src/esp_wireguard_err.h"
+    "src/esp_wireguard.c"
+)
+
+for file in "${required_files[@]}"; do
+    if ! printf '%s\n' "${normalised}" | grep -qx "${file}"; then
+        echo "::error::${file} is missing from the archive"
+        status=1
+    fi
+done
+
+if [ "${status}" -ne 0 ]; then
+    echo "Archive contents:"
+    printf '%s\n' "${normalised}" | sed 's/^/  /'
+    exit "${status}"
+fi
+
+echo "Archive contents match the files.exclude rules in idf_component.yml"

--- a/.github/scripts/check_component_archive.sh
+++ b/.github/scripts/check_component_archive.sh
@@ -33,9 +33,11 @@ if ! contents=$(tar -tzf "${archive}"); then
     exit 1
 fi
 
-# tar entries may or may not carry a leading "./", so compare on a normalised
-# copy rather than on the raw listing.
-normalised=$(printf '%s\n' "${contents}" | sed 's|^\./||')
+# Entry naming differs between packer versions: 2.5.0 and later prefix every
+# member with "./", while 2.4.0 writes them bare with a "/" root entry. Compare
+# on a normalised copy so the checks below hold either way, and so an absolute
+# member can never sidestep a prefix rule.
+normalised=$(printf '%s\n' "${contents}" | sed 's|^\./||; s|^/||')
 
 status=0
 

--- a/.github/scripts/check_component_archive.sh
+++ b/.github/scripts/check_component_archive.sh
@@ -49,8 +49,11 @@ excluded_files=(
     "TODO.md"
 )
 
+# Both loops match literally rather than as regexes. Every pattern here
+# contains a ".", which as a regex would match any character: "^TODO.md" also
+# matches "TODOxmd", and "^.github/" also matches "xgithub/".
 for prefix in "${excluded_prefixes[@]}"; do
-    matches=$(printf '%s\n' "${normalised}" | grep "^${prefix}" || true)
+    matches=$(printf '%s\n' "${normalised}" | awk -v p="${prefix}" 'index($0, p) == 1' || true)
     if [ -n "${matches}" ]; then
         echo "::error::${prefix} should be excluded but the archive contains:"
         printf '%s\n' "${matches}" | sed 's/^/  /'
@@ -59,7 +62,7 @@ for prefix in "${excluded_prefixes[@]}"; do
 done
 
 for file in "${excluded_files[@]}"; do
-    if printf '%s\n' "${normalised}" | grep -qx "${file}"; then
+    if printf '%s\n' "${normalised}" | grep -Fxq "${file}"; then
         echo "::error::${file} should be excluded but is present in the archive"
         status=1
     fi
@@ -76,7 +79,7 @@ required_files=(
 )
 
 for file in "${required_files[@]}"; do
-    if ! printf '%s\n' "${normalised}" | grep -qx "${file}"; then
+    if ! printf '%s\n' "${normalised}" | grep -Fxq "${file}"; then
         echo "::error::${file} is missing from the archive"
         status=1
     fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+
+permissions: {}
+
+jobs:
+  esp-idf:
+    name: ESP-IDF build (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - esp32
+          - esp32s3
+          - esp32c3
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Builds tests/idf, which pulls the repository root in as a component.
+      # This covers the idf_component_register() branch of CMakeLists.txt and
+      # the idf_component.yml manifest: the component manager resolves the
+      # declared esphome/libsodium dependency from the registry while
+      # configuring, and the link step then fails if it did not.
+      - name: Build the compile test for ${{ matrix.target }}
+        uses: espressif/esp-idf-ci-action@e6f5c74232b1ccd4c97ed641f1e48553853f1fd5 # v1.2.0
+        with:
+          esp_idf_version: v5.5.5
+          target: ${{ matrix.target }}
+          path: tests/idf
+
+  cmake:
+    name: CMake consumer configure
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # These steps configure only, and deliberately never build. The sources
+      # need lwip, mbedtls and libsodium headers, none of which a stock runner
+      # has, so compiling them off-target is not achievable without stubbing
+      # out most of an RTOS. What tests/cmake does check is the part this
+      # repository owns: that add_subdirectory() defines the documented
+      # targets, that the advertised include dirs really contain the public
+      # headers, and that the optional sodium link is guarded correctly.
+      - name: Configure with no sodium target present (configure only, no compile)
+        run: cmake -S tests/cmake -B "${RUNNER_TEMP}/cmake-without-sodium"
+
+      - name: Configure with a sodium target present (configure only, no compile)
+        run: >
+          cmake -S tests/cmake -B "${RUNNER_TEMP}/cmake-with-sodium"
+          -DWIREGUARD_TEST_WITH_SODIUM=ON
+
+  component-manifest:
+    name: Component manifest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      # Packing is what the release workflow's upload step does to
+      # idf_component.yml, so doing it here catches a malformed manifest or a
+      # broken files.exclude rule on the pull request instead of at release
+      # time.
+      - name: Pack the component
+        run: uv run --no-project --with idf-component-manager compote component pack --name wireguard
+
+      - name: Check the excluded paths are absent from the archive
+        run: .github/scripts/check_component_archive.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,16 @@ jobs:
       # idf_component.yml, so doing it here catches a malformed manifest or a
       # broken files.exclude rule on the pull request instead of at release
       # time.
+      #
+      # The version is pinned to the one espressif/upload-components-ci-action
+      # resolves in its own lockfile, so this job packs with the same code the
+      # release actually publishes with. Bump it together with that action's
+      # pin in publish.yml; left unpinned it floats to the latest release,
+      # which is currently two major versions ahead of the publisher.
       - name: Pack the component
-        run: uv run --no-project --with idf-component-manager compote component pack --name wireguard
+        run: >
+          uv run --no-project --with 'idf-component-manager==2.4.0'
+          compote component pack --name wireguard
 
       - name: Check the excluded paths are absent from the archive
         run: .github/scripts/check_component_archive.sh

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@
 /build/
 /dist/
 *.tar.gz
+
+# Build output of the projects under tests/
+build/
+managed_components/
+dependencies.lock
+sdkconfig
+sdkconfig.old

--- a/README.md
+++ b/README.md
@@ -73,6 +73,31 @@ This code targets only ESPHome and has been tested on the following platforms:
 * LibreTiny (with `bk72` microcontrollers only)
 
 
+## Tests
+
+`tests/` holds two compile tests for the build files, both run by CI on every
+pull request:
+
+* `tests/idf` is a minimal ESP-IDF project that pulls the repository root in as
+  a component and calls into `esp_wireguard.h`. It covers `CMakeLists.txt` and
+  `idf_component.yml` together: the component manager resolves the declared
+  `esphome/libsodium` dependency from the registry while configuring, and the
+  link step fails if it did not. Build it with `idf.py -C tests/idf build`
+  after running ESP-IDF's `export` script.
+
+* `tests/cmake` is a consumer project for the plain CMake path. It only
+  configures and never compiles, because as described above that branch is not
+  a portable host build: the sources expect lwip, mbedtls, libsodium and an
+  ESP-family SDK, none of which a stock host has. It checks what this
+  repository is responsible for, which is that `add_subdirectory()` defines the
+  documented targets, that the advertised include dirs contain the public
+  headers, and that the optional `sodium` link is guarded correctly.
+
+  ```console
+  cmake -S tests/cmake -B build/cmake-test
+  ```
+
+
 ## References
 
 For additional information see:

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -9,3 +9,4 @@ files:
   exclude:
     - ".github/**/*"
     - "TODO.md"
+    - "tests/**/*"

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -1,0 +1,85 @@
+# Consumer project for the non-ESP-IDF branch of the top level CMakeLists.txt.
+#
+# This is a configure-time test, not a compile test. The sources need lwip,
+# mbedtls and libsodium headers, none of which exist on a stock host, so
+# building them here is not achievable without stubbing out most of an RTOS.
+# What is worth checking is the part this repository actually owns: that
+# add_subdirectory() defines the documented targets, that the include
+# directories it advertises really contain the public headers, that the
+# warning suppression is applied, and that the optional sodium link is guarded
+# correctly. Everything below runs during `cmake -S ... -B ...`; there is
+# deliberately no build step.
+cmake_minimum_required(VERSION 3.13)
+
+project(wireguard_cmake_consumer C)
+
+# The if(TARGET sodium) guard in the library has two branches, so the test is
+# configured twice: once with a sodium target already defined and once without.
+option(WIREGUARD_TEST_WITH_SODIUM "Define a sodium target before add_subdirectory()" OFF)
+
+if(WIREGUARD_TEST_WITH_SODIUM)
+  add_library(sodium INTERFACE)
+endif()
+
+# Generating would already fail here if any source listed in WIREGUARD_SRCS had
+# been renamed or removed.
+add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../.." wireguard)
+
+function(expect_target target)
+  if(NOT TARGET ${target})
+    message(FATAL_ERROR "expected add_subdirectory() to define the target '${target}'")
+  endif()
+endfunction()
+
+expect_target(wireguard)
+expect_target(esphome::wireguard)
+
+# The README tells consumers to link esphome::wireguard, so link it for real
+# rather than only asserting that the alias exists.
+add_library(consumer INTERFACE)
+target_link_libraries(consumer INTERFACE esphome::wireguard)
+
+# Public headers must be reachable through the advertised include dirs. Both
+# entries matter: esp_wireguard.h is in include/, and the esp_wireguard_err.h
+# it includes is in src/, which is why src is public.
+get_target_property(include_dirs wireguard INTERFACE_INCLUDE_DIRECTORIES)
+if(NOT include_dirs)
+  message(FATAL_ERROR "wireguard has no INTERFACE_INCLUDE_DIRECTORIES")
+endif()
+
+foreach(header "esp_wireguard.h" "esp_wireguard_err.h")
+  set(found NO)
+  foreach(dir ${include_dirs})
+    if(EXISTS "${dir}/${header}")
+      set(found YES)
+    endif()
+  endforeach()
+  if(NOT found)
+    message(FATAL_ERROR
+      "'${header}' is not reachable through the public include dirs: ${include_dirs}")
+  endif()
+endforeach()
+
+get_target_property(compile_options wireguard COMPILE_OPTIONS)
+if(NOT "-Wno-unused-result" IN_LIST compile_options)
+  message(FATAL_ERROR
+    "expected -Wno-unused-result on the wireguard target, got: ${compile_options}")
+endif()
+
+get_target_property(link_libraries wireguard LINK_LIBRARIES)
+if(NOT link_libraries)
+  set(link_libraries "")
+endif()
+if(WIREGUARD_TEST_WITH_SODIUM)
+  if(NOT "sodium" IN_LIST link_libraries)
+    message(FATAL_ERROR
+      "a sodium target exists, so wireguard should link it, got: ${link_libraries}")
+  endif()
+else()
+  if("sodium" IN_LIST link_libraries)
+    message(FATAL_ERROR
+      "no sodium target exists, so wireguard should not link it, got: ${link_libraries}")
+  endif()
+endif()
+
+message(STATUS "wireguard CMake consumer checks passed (sodium target: ${WIREGUARD_TEST_WITH_SODIUM})")

--- a/tests/idf/CMakeLists.txt
+++ b/tests/idf/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Minimal ESP-IDF project that builds the repository root as a component.
+#
+# This exercises both files the component build is made of: CMakeLists.txt, via
+# the idf_component_register() branch, and idf_component.yml, whose
+# esphome/libsodium dependency the component manager resolves from the
+# component registry while configuring this project.
+#
+# main requires that component by name and nothing else, so main.c is compiled
+# with only what the component makes public. That is what gives the test its
+# teeth: if include/ or src/ stops being a public include dir, or lwip stops
+# being a public REQUIRES, main.c stops compiling.
+cmake_minimum_required(VERSION 3.16)
+
+get_filename_component(WIREGUARD_COMPONENT_DIR "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+set(EXTRA_COMPONENT_DIRS "${WIREGUARD_COMPONENT_DIR}")
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(wireguard_idf_compile_test)

--- a/tests/idf/main/CMakeLists.txt
+++ b/tests/idf/main/CMakeLists.txt
@@ -1,0 +1,16 @@
+# ESP-IDF gives a component the name of its directory, and the name of the
+# checkout directory is not fixed: it is "wireguard" in CI, but a clone or a
+# git worktree can be called anything. Derive it here rather than reading a
+# variable set by the top level CMakeLists.txt, because ESP-IDF resolves
+# REQUIRES in a separate `cmake -P` subprocess that does not see project
+# variables, and an empty REQUIRES would silently fall back to main's
+# "depend on every component in the build" behaviour. That fallback would
+# hand main every include dir in the build and mask a component whose
+# INCLUDE_DIRS or REQUIRES are wrong, which is the thing under test.
+get_filename_component(WIREGUARD_COMPONENT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+get_filename_component(WIREGUARD_COMPONENT_NAME "${WIREGUARD_COMPONENT_DIR}" NAME)
+
+idf_component_register(
+  SRCS "main.c"
+  REQUIRES ${WIREGUARD_COMPONENT_NAME}
+)

--- a/tests/idf/main/main.c
+++ b/tests/idf/main/main.c
@@ -1,0 +1,51 @@
+/*
+ * Compile test for the ESP-IDF component build.
+ *
+ * This is not a functional test: nothing here is expected to succeed at
+ * runtime, and the firmware is never flashed. The point is to reference every
+ * type, macro and function the public header exposes, so that a broken
+ * component build fails at compile or link time.
+ */
+#include <time.h>
+
+#include "esp_err.h"
+#include "esp_wireguard.h"
+
+/* The two DEFAULT macros are the awkward part of the public API: they use
+ * designated initialisers and lwip's IPADDR4_INIT(), so they only compile if
+ * the component's public include dirs are wired up. */
+static wireguard_config_t s_config = ESP_WIREGUARD_CONFIG_DEFAULT();
+static wireguard_ctx_t s_ctx = ESP_WIREGUARD_CONTEXT_DEFAULT();
+
+void app_main(void)
+{
+    time_t handshake = 0;
+
+    s_config.private_key = "private";
+    s_config.public_key = "public";
+    s_config.preshared_key = "preshared";
+    s_config.address = "10.0.0.2";
+    s_config.netmask = "255.255.255.0";
+    s_config.endpoint = "wireguard.example.com";
+    s_config.port = 51820;
+    s_config.listen_port = 51820;
+    s_config.fw_mark = 0;
+    s_config.persistent_keepalive = 30;
+
+    /* esp_wireguard_err.h lives in src/, not include/, and is reachable only
+     * because src is registered as a public include dir. */
+    if (esp_wireguard_init(&s_config, &s_ctx) != ESP_OK) {
+        return;
+    }
+    if (esp_wireguard_connect(&s_ctx) == ESP_ERR_INVALID_IP) {
+        return;
+    }
+
+    (void) esp_wireguard_set_default(&s_ctx);
+    (void) esp_wireguard_peer_is_up(&s_ctx);
+    (void) esp_wireguardif_peer_is_up(&s_ctx);
+    (void) esp_wireguard_latest_handshake(&s_ctx, &handshake);
+    (void) esp_wireguard_add_allowed_ip(&s_ctx, "192.168.1.0", "255.255.255.0");
+    (void) esp_wireguard_restore_default(&s_ctx);
+    (void) esp_wireguard_disconnect(&s_ctx);
+}


### PR DESCRIPTION
The build files added in #15 had no coverage, so a renamed source or a dropped include dir would only surface once it reached a consumer. This adds a compile test for each of the two build paths and a `ci.yml` to run them on pull requests.

## ESP-IDF

`tests/idf` is a minimal project that builds the repository root as a component, for `esp32`, `esp32s3` and `esp32c3`. `main.c` references every type, macro and function the public header exposes, so a missing symbol fails at link time. Configuring it also resolves the `esphome/libsodium` dependency declared in `idf_component.yml` from the registry, which means the manifest is exercised alongside `CMakeLists.txt`.

Two details in there are deliberate and worth a note for review:

- The component name is derived with `get_filename_component(... NAME)` rather than hardcoded, because ESP-IDF names a component after its directory and the checkout directory is only called `wireguard` in CI. A clone or a git worktree can be called anything. This is also why `override_path` in a manifest is not used here: it has the same directory-name constraint.
- That derivation lives in `main/CMakeLists.txt` rather than being passed down from the project's top level. ESP-IDF resolves `REQUIRES` in a separate `cmake -P` subprocess that cannot see project variables, and an empty `REQUIRES` silently triggers main's "depend on every component in the build" fallback. That fallback hands main all ~175 include dirs in the build and masks exactly what the test is trying to check; requiring the component by name keeps it at 52.

## Plain CMake

`tests/cmake` configures a consumer of the `add_subdirectory()` path and **deliberately does not compile anything**. As #15's README now says, that branch is not a portable host build: the sources expect lwip, mbedtls, libsodium and an ESP-family SDK, so a real host compile is not reachable without stubbing out most of an RTOS. Rather than fake a passing compile, this checks what the repository actually owns, which is that the `wireguard` target and `esphome::wireguard` alias are defined, that the advertised include dirs really contain `esp_wireguard.h` and `esp_wireguard_err.h`, that `-Wno-unused-result` lands on the target, and that the `if(TARGET sodium)` guard behaves in both directions. The configure-only scope is stated in the workflow step names, the file's own header comment and the README.

## Scope, honestly

I negative-tested every assertion by breaking it and checking the test noticed. Two of the declarations in `CMakeLists.txt` turn out not to be falsifiable by any compile test, so this PR does not claim to cover them:

- Removing `REQUIRES lwip` still builds, because lwip's headers reach every component through ESP-IDF's common requirements.
- Removing `PRIV_REQUIRES esphome__libsodium` still builds, because the component manager re-injects manifest dependencies regardless of what `idf_component_register()` declares.

The manifest is the real enforcement point for the second one, and that *is* covered: deleting the `esphome/libsodium` line fails configure with `Failed to resolve component 'esphome__libsodium'`. Removing `"src"` from `INCLUDE_DIRS` likewise fails with `esp_wireguard_err.h: No such file or directory`, which is the specific reason #15 made `src` a public include dir.

## Also here

`tests/**/*` is added to `files.exclude` so the test projects are not published to the component registry, and a small `component-manifest` job packs the component and asserts the exclude rules kept `.github`, `TODO.md` and `tests` out while leaving the files a consumer needs in. All actions are pinned to peeled commit SHAs.

## Verification

All three targets were built locally with the same `espressif/idf:v5.5.5` image and command the CI action uses, with `esphome/libsodium 1.10021.2` resolving from the registry each time. I also compiled an ESPHome config using the `wireguard` component against this branch on both the `esp-idf` and `arduino` frameworks to confirm nothing regressed on the PlatformIO path. `actionlint` and `shellcheck` are clean.