### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` so the SHA-pinned actions in `publish.yml` and `release-drafter.yml` stay current. Updates are grouped into a single weekly PR and labelled `dependencies`, which matches the Dependencies category and the patch version-resolver in `.github/release-drafter.yml`.

GitHub Actions is the only ecosystem Dependabot supports for this repo - the `esphome/libsodium` dependency in `idf_component.yml` and the PlatformIO metadata in `library.json` are not covered by any Dependabot ecosystem.